### PR TITLE
Remove lone tab from match_dense.py (#327)

### DIFF
--- a/hloc/match_dense.py
+++ b/hloc/match_dense.py
@@ -100,7 +100,7 @@ def assign_keypoints(kpts: np.ndarray,
                      cell_size: Optional[int] = None):
     if not update:
         # Without update this is just a NN search
-	if len(other_cpts) == 0 or len(kpts) == 0:
+        if len(other_cpts) == 0 or len(kpts) == 0:
             return np.full(len(kpts), -1)
         dist, kpt_ids = KDTree(np.array(other_cpts)).query(kpts)
         valid = (dist <= max_error)


### PR DESCRIPTION
Fixes the error: `TabError: inconsistent use of tabs and spaces in indentation`. Changes to spaces, like the rest of the file.